### PR TITLE
Add key event handling for arc

### DIFF
--- a/concrete.lua
+++ b/concrete.lua
@@ -2189,6 +2189,10 @@ function a.delta(n, d)
   _arc.delta(n, d)
 end
 
+function a.key (n,z)
+    _arc.key(n,z)
+end
+
 function arcredraw()
   _arc.draw()
 end

--- a/lib/concrete_arc.lua
+++ b/lib/concrete_arc.lua
@@ -5,6 +5,10 @@ for i = 1, 4 do
   enc_count[i] = 0
 end
 
+function arcenc.key (n,z)
+    -- toggle shift on/off when key is pressed
+    shift = z == 1 and true or false
+end
 
 function arcenc.delta(n, d)
   if pageNum < 3 then


### PR DESCRIPTION
Add super-simple support for 2025 Arc button events in both concrete.lua and concrete_arc.lua. Pressing the Arc button is equivalent to pressing the shift button on Norns.